### PR TITLE
feat: build generic-screen Game Couch MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,79 @@
 # Game Couch
 
-A game-presence harness for sharing play sessions with AI companions as real Discord participants.
+A local game-presence harness for sharing play sessions with AI companions as real Discord participants.
 
-The project starts with a tiny, game-agnostic MVP: a local CLI/service captures player-triggered moments, posts screenshot/context bundles into a Discord session room, and keeps a session journal. Game-specific plugins can later add richer telemetry and control surfaces.
+Game Couch is stagehand infrastructure, not a merged bot persona. The player drives; Pip, Coda, and friends can react in Discord to player-triggered moments that include a screenshot, note, and lightweight plugin context.
+
+## MVP model
+
+- Local CLI starts or reuses a play session.
+- `generic-screen` is the first game-agnostic plugin.
+- `game-couch share` posts a manual moment bundle.
+- Journals are written locally as JSONL per session.
+- Automated tests use a dry-run transport so no Discord messages are sent.
+
+Non-goals for v0: WoW-specific integration, wheel/autonomous control mode, console capture cards, and always-on video.
+
+## Install for local development
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e . pytest
+```
+
+## Start a couch session
+
+```bash
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff"
+```
+
+This writes session metadata under:
+
+```text
+~/.local/share/game-couch/sessions/<session-id>/
+```
+
+Set `GAME_COUCH_HOME=/path/to/dir` to use a different storage location.
+
+## Share a manual moment
+
+Safest dry-run flow:
+
+```bash
+game-couch share --note "look at this jump" --screenshot ~/Desktop/moment.png --transport dry-run
+```
+
+If `--screenshot` is omitted, `generic-screen` attempts a one-shot macOS `screencapture`. On other systems, pass a screenshot path explicitly.
+
+Moment payloads include:
+
+- session id
+- game id
+- player label
+- trigger
+- timestamp
+- optional note
+- screenshot/media path
+- plugin context
+
+## Discord config
+
+The MVP Discord transport posts via webhook:
+
+```bash
+export GAME_COUCH_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+game-couch share --note "boss down" --screenshot ~/Desktop/moment.png --transport discord
+```
+
+Do not commit webhook URLs or bot tokens. Tests and local development should prefer `--transport dry-run`.
+
+## Plugin interface
+
+See [`docs/plugins.md`](docs/plugins.md). The implemented plugin is `generic-screen`.
+
+## Tests
+
+```bash
+pytest
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,8 +1,27 @@
 # Testing
 
-MVP should include:
+MVP coverage includes:
 
-- Unit tests for plugin interface and moment payload shaping.
-- CLI smoke tests for session start and manual capture command paths.
-- A dry-run Discord transport for tests so no real messages are sent in CI.
-- Manual local test notes for real Discord posting.
+- Unit tests for moment payload shaping.
+- Unit tests for plugin loading and `generic-screen` start context.
+- Unit tests for journal JSONL writing and dry-run transport outbox writing.
+- CLI smoke test for `game-couch start` and `game-couch share` with `--transport dry-run`.
+
+Run locally:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e . pytest
+pytest
+```
+
+Dry-run transport is the default for `game-couch share`, so CI and local tests do not send real Discord messages.
+
+Manual Discord posting check, when a webhook is intentionally configured:
+
+```bash
+export GAME_COUCH_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff"
+game-couch share --note "manual webhook check" --screenshot /path/to/screenshot.png --transport discord
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,21 @@
+# Plugin Interface
+
+Game Couch keeps the core game-agnostic. A plugin supplies the minimum game-specific context needed for a couch moment.
+
+A plugin implements `GamePlugin` from `game_couch.plugins.base`:
+
+- `game_id`: stable CLI id, for example `generic-screen`
+- `start_context(session)`: lightweight context recorded when a play session starts
+- `capture_moment_context(session, screenshot_path)`: context bundled with each shared moment
+- `capture_screenshot(destination)`: optional helper for player-triggered capture when no screenshot path is supplied
+
+## `generic-screen`
+
+The MVP plugin is deliberately plain desktop context:
+
+- no game API integration
+- no WoW-specific behavior
+- no always-on stream
+- no autonomous control
+
+`game-couch share --screenshot /path/to/file.png` is the safest path. On macOS, omitting `--screenshot` attempts a one-shot `screencapture` into the current session's `captures/` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "game-couch"
+version = "0.1.0"
+description = "Local game-presence harness for sharing player-triggered game moments."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Pipseed AI" }]
+
+[project.scripts]
+game-couch = "game_couch.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/game_couch/cli.py
+++ b/src/game_couch/cli.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import json
+import sys
+
+from .plugins.registry import available_plugins
+from .service import share_moment, start_session
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="game-couch", description="Share player-triggered game moments into a couch session.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start", help="Create or reuse a play session context.")
+    start.add_argument("--game", required=True, choices=available_plugins())
+    start.add_argument("--channel", required=True, help="Discord channel/thread target label or id.")
+    start.add_argument("--player-label", default="Player")
+    start.add_argument("--new", action="store_true", help="Force a new session instead of reusing the current matching one.")
+    start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    share = sub.add_parser("share", help="Capture or send a manual moment bundle.")
+    share.add_argument("--note", default=None)
+    share.add_argument("--screenshot", type=Path, default=None, help="Existing screenshot/media path. If omitted, generic-screen tries local capture.")
+    share.add_argument("--trigger", default="manual")
+    share.add_argument("--transport", choices=["dry-run", "discord"], default="dry-run")
+    share.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    sub.add_parser("plugins", help="List available game plugins.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "start":
+            session, reused, plugin_context = start_session(
+                game_id=args.game,
+                channel=args.channel,
+                player_label=args.player_label,
+                force_new=args.new,
+            )
+            output = {"session": session.to_dict(), "reused": reused, "plugin_context": plugin_context}
+            if args.json:
+                print(json.dumps(output, indent=2, sort_keys=True))
+            else:
+                verb = "Reusing" if reused else "Started"
+                print(f"{verb} Game Couch session {session.session_id} for {session.game_id} in {session.channel}")
+                print(f"Journal: {session.journal_path}")
+            return 0
+        if args.command == "share":
+            session, payload, result = share_moment(
+                note=args.note,
+                screenshot=args.screenshot,
+                trigger=args.trigger,
+                transport_name=args.transport,
+            )
+            output = {"session": session.to_dict(), "payload": payload, "transport": result}
+            if args.json:
+                print(json.dumps(output, indent=2, sort_keys=True))
+            else:
+                print(f"Shared moment for session {session.session_id} via {result['transport']}")
+                print(f"Journal: {session.journal_path}")
+            return 0
+        if args.command == "plugins":
+            for plugin in available_plugins():
+                print(plugin)
+            return 0
+    except Exception as exc:  # CLI boundary
+        print(f"game-couch: error: {exc}", file=sys.stderr)
+        return 1
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/game_couch/journal.py
+++ b/src/game_couch/journal.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any
+
+from .models import MomentPayload, SessionContext
+
+
+class Journal:
+    def __init__(self, session: SessionContext):
+        if not session.journal_path:
+            raise ValueError("session.journal_path is required")
+        self.path = Path(session.journal_path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, kind: str, data: dict[str, Any]) -> None:
+        record = {"kind": kind, "data": data}
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    def append_session_started(self, session: SessionContext, reused: bool) -> None:
+        self.append("session.started", {**session.to_dict(), "reused": reused})
+
+    def append_moment(self, payload: MomentPayload, transport_result: dict[str, Any]) -> None:
+        self.append("moment.shared", {"payload": payload.to_dict(), "transport": transport_result})

--- a/src/game_couch/models.py
+++ b/src/game_couch/models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+import uuid
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def new_session_id(game_id: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{game_id}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+@dataclass(slots=True)
+class SessionContext:
+    session_id: str
+    game_id: str
+    channel: str
+    player_label: str = "Player"
+    created_at: str = field(default_factory=utc_now_iso)
+    journal_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SessionContext":
+        return cls(**data)
+
+
+@dataclass(slots=True)
+class MomentPayload:
+    session_id: str
+    game_id: str
+    player_label: str
+    trigger: str
+    timestamp: str
+    note: str | None
+    screenshot_path: str | None
+    media_path: str | None
+    plugin_context: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def shape_moment_payload(
+    *,
+    session: SessionContext,
+    trigger: str,
+    note: str | None,
+    screenshot_path: str | Path | None,
+    plugin_context: dict[str, Any],
+    timestamp: str | None = None,
+) -> MomentPayload:
+    media_path = str(screenshot_path) if screenshot_path else None
+    return MomentPayload(
+        session_id=session.session_id,
+        game_id=session.game_id,
+        player_label=session.player_label,
+        trigger=trigger,
+        timestamp=timestamp or utc_now_iso(),
+        note=note,
+        screenshot_path=media_path,
+        media_path=media_path,
+        plugin_context=plugin_context,
+    )

--- a/src/game_couch/paths.py
+++ b/src/game_couch/paths.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+
+def couch_home() -> Path:
+    return Path(os.environ.get("GAME_COUCH_HOME", Path.home() / ".local" / "share" / "game-couch")).expanduser()
+
+
+def sessions_dir(home: Path | None = None) -> Path:
+    return (home or couch_home()) / "sessions"
+
+
+def current_session_path(home: Path | None = None) -> Path:
+    return (home or couch_home()) / "current-session.json"

--- a/src/game_couch/plugins/base.py
+++ b/src/game_couch/plugins/base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from game_couch.models import SessionContext
+
+
+class GamePlugin(ABC):
+    """Interface implemented by game-specific context providers."""
+
+    game_id: str
+
+    @abstractmethod
+    def start_context(self, session: SessionContext) -> dict[str, Any]:
+        """Return lightweight context saved when a session starts."""
+
+    @abstractmethod
+    def capture_moment_context(self, *, session: SessionContext, screenshot_path: Path | None) -> dict[str, Any]:
+        """Return plugin-specific context for a player-triggered moment."""
+
+    def capture_screenshot(self, destination: Path) -> Path:
+        """Capture a screenshot into destination, if supported by the plugin/environment."""
+        raise NotImplementedError(f"{self.game_id} does not support automatic screenshot capture here")

--- a/src/game_couch/plugins/generic_screen.py
+++ b/src/game_couch/plugins/generic_screen.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+from typing import Any
+
+from game_couch.models import SessionContext
+from game_couch.plugins.base import GamePlugin
+
+
+class GenericScreenPlugin(GamePlugin):
+    game_id = "generic-screen"
+
+    def start_context(self, session: SessionContext) -> dict[str, Any]:
+        return {
+            "plugin": self.game_id,
+            "mode": "manual-screen-moments",
+            "capture": "screenshot-path-or-local-screencapture",
+            "channel": session.channel,
+        }
+
+    def capture_moment_context(self, *, session: SessionContext, screenshot_path: Path | None) -> dict[str, Any]:
+        return {
+            "plugin": self.game_id,
+            "source": "generic desktop screen",
+            "screenshot_provided": screenshot_path is not None,
+            "screenshot_filename": screenshot_path.name if screenshot_path else None,
+        }
+
+    def capture_screenshot(self, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if platform.system() == "Darwin" and shutil.which("screencapture"):
+            subprocess.run(["screencapture", "-x", str(destination)], check=True)
+            return destination
+        raise RuntimeError(
+            "Automatic screenshot capture is only implemented for macOS with screencapture; "
+            "pass --screenshot instead."
+        )

--- a/src/game_couch/plugins/registry.py
+++ b/src/game_couch/plugins/registry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from game_couch.plugins.base import GamePlugin
+from game_couch.plugins.generic_screen import GenericScreenPlugin
+
+_PLUGINS: dict[str, type[GamePlugin]] = {
+    GenericScreenPlugin.game_id: GenericScreenPlugin,
+}
+
+
+def load_plugin(game_id: str) -> GamePlugin:
+    try:
+        return _PLUGINS[game_id]()
+    except KeyError as exc:
+        known = ", ".join(sorted(_PLUGINS))
+        raise ValueError(f"Unknown game plugin '{game_id}'. Known plugins: {known}") from exc
+
+
+def available_plugins() -> list[str]:
+    return sorted(_PLUGINS)

--- a/src/game_couch/service.py
+++ b/src/game_couch/service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from .journal import Journal
+from .models import SessionContext, new_session_id, shape_moment_payload
+from .paths import couch_home, current_session_path, sessions_dir
+from .plugins.registry import load_plugin
+from .transport import make_transport
+
+
+def start_session(
+    *,
+    game_id: str,
+    channel: str,
+    player_label: str = "Player",
+    home: Path | None = None,
+    force_new: bool = False,
+) -> tuple[SessionContext, bool, dict]:
+    home = home or couch_home()
+    current_path = current_session_path(home)
+    if not force_new and current_path.exists():
+        current = SessionContext.from_dict(json.loads(current_path.read_text(encoding="utf-8")))
+        if current.game_id == game_id and current.channel == channel and current.player_label == player_label:
+            plugin_context = load_plugin(game_id).start_context(current)
+            Journal(current).append_session_started(current, reused=True)
+            return current, True, plugin_context
+
+    session_id = new_session_id(game_id)
+    session_dir = sessions_dir(home) / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session = SessionContext(
+        session_id=session_id,
+        game_id=game_id,
+        channel=channel,
+        player_label=player_label,
+        journal_path=str(session_dir / "journal.jsonl"),
+    )
+    plugin_context = load_plugin(game_id).start_context(session)
+    (session_dir / "session.json").write_text(json.dumps(session.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    current_path.parent.mkdir(parents=True, exist_ok=True)
+    current_path.write_text(json.dumps(session.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    Journal(session).append_session_started(session, reused=False)
+    return session, False, plugin_context
+
+
+def load_current_session(*, home: Path | None = None) -> SessionContext:
+    path = current_session_path(home or couch_home())
+    if not path.exists():
+        raise RuntimeError("No active Game Couch session. Run 'game-couch start --game generic-screen --channel <target>' first.")
+    return SessionContext.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def share_moment(
+    *,
+    note: str | None,
+    screenshot: Path | None,
+    trigger: str = "manual",
+    transport_name: str = "dry-run",
+    home: Path | None = None,
+) -> tuple[SessionContext, dict, dict]:
+    home = home or couch_home()
+    session = load_current_session(home=home)
+    plugin = load_plugin(session.game_id)
+
+    screenshot_path = screenshot
+    if screenshot_path is None:
+        captures_dir = sessions_dir(home) / session.session_id / "captures"
+        screenshot_path = plugin.capture_screenshot(captures_dir / f"{trigger}.png")
+    else:
+        screenshot_path = screenshot_path.expanduser().resolve()
+        if not screenshot_path.exists():
+            raise FileNotFoundError(f"Screenshot does not exist: {screenshot_path}")
+
+    plugin_context = plugin.capture_moment_context(session=session, screenshot_path=screenshot_path)
+    payload = shape_moment_payload(
+        session=session,
+        trigger=trigger,
+        note=note,
+        screenshot_path=screenshot_path,
+        plugin_context=plugin_context,
+    )
+    outbox_path = sessions_dir(home) / session.session_id / "dry-run-outbox.jsonl"
+    transport = make_transport(transport_name, outbox_path=outbox_path)
+    result = transport.send_moment(session=session, payload=payload)
+    Journal(session).append_moment(payload, result)
+    return session, payload.to_dict(), result

--- a/src/game_couch/transport.py
+++ b/src/game_couch/transport.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+import json
+import os
+import urllib.request
+
+from .models import MomentPayload, SessionContext
+
+
+class Transport(ABC):
+    @abstractmethod
+    def send_moment(self, *, session: SessionContext, payload: MomentPayload) -> dict[str, Any]:
+        """Send a moment bundle and return delivery metadata."""
+
+
+class DryRunTransport(Transport):
+    def __init__(self, outbox_path: Path | None = None):
+        self.outbox_path = outbox_path
+
+    def send_moment(self, *, session: SessionContext, payload: MomentPayload) -> dict[str, Any]:
+        record = {"channel": session.channel, "payload": payload.to_dict()}
+        if self.outbox_path:
+            self.outbox_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.outbox_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+        return {"transport": "dry-run", "delivered": False, "channel": session.channel, "outbox": str(self.outbox_path) if self.outbox_path else None}
+
+
+class DiscordWebhookTransport(Transport):
+    def __init__(self, webhook_url: str | None = None):
+        self.webhook_url = webhook_url or os.environ.get("GAME_COUCH_DISCORD_WEBHOOK_URL") or os.environ.get("DISCORD_WEBHOOK_URL")
+        if not self.webhook_url:
+            raise RuntimeError("Discord transport requires GAME_COUCH_DISCORD_WEBHOOK_URL or DISCORD_WEBHOOK_URL")
+
+    def send_moment(self, *, session: SessionContext, payload: MomentPayload) -> dict[str, Any]:
+        body = {
+            "content": format_discord_message(session=session, payload=payload),
+            "allowed_mentions": {"parse": []},
+        }
+        request = urllib.request.Request(
+            self.webhook_url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json", "User-Agent": "game-couch/0.1"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=15) as response:  # noqa: S310 - user-configured Discord webhook
+            status = response.getcode()
+        return {"transport": "discord-webhook", "delivered": True, "channel": session.channel, "status": status}
+
+
+def format_discord_message(*, session: SessionContext, payload: MomentPayload) -> str:
+    lines = [
+        f"🎮 **Game Couch moment** — `{payload.game_id}`",
+        f"Session: `{payload.session_id}` | Player: **{payload.player_label}** | Trigger: `{payload.trigger}`",
+        f"Time: {payload.timestamp}",
+    ]
+    if payload.note:
+        lines.append(f"Note: {payload.note}")
+    if payload.media_path:
+        lines.append(f"Screenshot: `{payload.media_path}`")
+    lines.append(f"Plugin context: ```json\n{json.dumps(payload.plugin_context, sort_keys=True)}\n```")
+    return "\n".join(lines)
+
+
+def make_transport(name: str, *, outbox_path: Path | None = None) -> Transport:
+    if name == "dry-run":
+        return DryRunTransport(outbox_path=outbox_path)
+    if name == "discord":
+        return DiscordWebhookTransport()
+    raise ValueError("transport must be 'dry-run' or 'discord'")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import json
+
+from game_couch.cli import main
+
+
+def test_cli_start_and_share_dry_run(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("GAME_COUCH_HOME", str(tmp_path / "home"))
+    screenshot = tmp_path / "screen.png"
+    screenshot.write_bytes(b"fake-png")
+
+    assert main(["start", "--game", "generic-screen", "--channel", "#games", "--player-label", "Saff", "--json"]) == 0
+    start_output = json.loads(capsys.readouterr().out)
+    session = start_output["session"]
+
+    assert session["game_id"] == "generic-screen"
+    assert session["channel"] == "#games"
+    assert session["player_label"] == "Saff"
+
+    assert main(["share", "--note", "nice jump", "--screenshot", str(screenshot), "--transport", "dry-run", "--json"]) == 0
+    share_output = json.loads(capsys.readouterr().out)
+
+    assert share_output["payload"]["session_id"] == session["session_id"]
+    assert share_output["payload"]["note"] == "nice jump"
+    assert share_output["transport"]["transport"] == "dry-run"
+    assert (tmp_path / "home" / "sessions" / session["session_id"] / "journal.jsonl").exists()

--- a/tests/test_journal_transport.py
+++ b/tests/test_journal_transport.py
@@ -1,0 +1,35 @@
+import json
+
+from game_couch.journal import Journal
+from game_couch.models import SessionContext, shape_moment_payload
+from game_couch.transport import DryRunTransport
+
+
+def test_journal_writes_jsonl_and_dry_run_transport_records_outbox(tmp_path):
+    session = SessionContext(
+        session_id="s1",
+        game_id="generic-screen",
+        channel="#games",
+        journal_path=str(tmp_path / "journal.jsonl"),
+    )
+    payload = shape_moment_payload(
+        session=session,
+        trigger="manual",
+        note=None,
+        screenshot_path=tmp_path / "screen.png",
+        plugin_context={"plugin": "generic-screen"},
+        timestamp="2026-04-28T21:00:00Z",
+    )
+    outbox = tmp_path / "outbox.jsonl"
+
+    result = DryRunTransport(outbox).send_moment(session=session, payload=payload)
+    Journal(session).append_moment(payload, result)
+
+    outbox_record = json.loads(outbox.read_text().splitlines()[0])
+    journal_record = json.loads((tmp_path / "journal.jsonl").read_text().splitlines()[0])
+
+    assert result["transport"] == "dry-run"
+    assert result["delivered"] is False
+    assert outbox_record["payload"]["session_id"] == "s1"
+    assert journal_record["kind"] == "moment.shared"
+    assert journal_record["data"]["payload"]["game_id"] == "generic-screen"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+from game_couch.models import SessionContext, shape_moment_payload
+
+
+def test_moment_payload_shape_contains_required_fields():
+    session = SessionContext(session_id="s1", game_id="generic-screen", channel="#games", player_label="Saff")
+    payload = shape_moment_payload(
+        session=session,
+        trigger="manual",
+        note="look at this",
+        screenshot_path="/tmp/screen.png",
+        plugin_context={"plugin": "generic-screen"},
+        timestamp="2026-04-28T21:00:00Z",
+    ).to_dict()
+
+    assert payload == {
+        "session_id": "s1",
+        "game_id": "generic-screen",
+        "player_label": "Saff",
+        "trigger": "manual",
+        "timestamp": "2026-04-28T21:00:00Z",
+        "note": "look at this",
+        "screenshot_path": "/tmp/screen.png",
+        "media_path": "/tmp/screen.png",
+        "plugin_context": {"plugin": "generic-screen"},
+    }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,11 @@
+from game_couch.models import SessionContext
+from game_couch.plugins.registry import available_plugins, load_plugin
+
+
+def test_loads_generic_screen_plugin():
+    plugin = load_plugin("generic-screen")
+    session = SessionContext(session_id="s1", game_id="generic-screen", channel="#games")
+
+    assert "generic-screen" in available_plugins()
+    assert plugin.game_id == "generic-screen"
+    assert plugin.start_context(session)["mode"] == "manual-screen-moments"


### PR DESCRIPTION
## Summary
- Adds a Python `game-couch` CLI with `start`, `share`, and `plugins` commands.
- Implements the game-agnostic session/moment core, `generic-screen` plugin, local JSONL journal, dry-run transport, and Discord webhook transport.
- Documents setup, dry-run/Discord usage, and the plugin interface.

## Tests
- `python3 -m pytest`

Refs #1