### PR TITLE
docs: formalize Game Couch testable-stage plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This writes session metadata under:
 
 Set `GAME_COUCH_HOME=/path/to/dir` to use a different storage location.
 
+## Testable-stage direction
+
+The next stage is documented in [`docs/testable-stage-plan.md`](docs/testable-stage-plan.md): split coordinator, runner, plugin, and transport/RTC seams so a real `bigchoof` couch session can be tested without jumping straight to WebRTC or arbitrary remote shell execution.
+
 ## Share a manual moment
 
 Safest dry-run flow:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,11 @@
 
 ## Now
 
-- Follow the testable-stage plan in `docs/testable-stage-plan.md`.
-- Add remote runner/SSH tunnel support for `bigchoof`.
+- Keep the testable-stage plan in `docs/testable-stage-plan.md` as the implementation contract.
+- Build the remote runner seam for `bigchoof` with fake/local tests before live SSH.
+- Add remote `generic-screen` screenshot capture and artifact fetch.
 - Make Discord couch-room posting feel good enough for one real session.
-- Write and run the first manual couch-session eval.
+- Rehearse, then run, the first manual couch-session eval in `docs/evals/testable-couch-session.md`.
 
 ## Next
 

--- a/docs/adr/0001-testable-stage-rtc-and-runner-boundary.md
+++ b/docs/adr/0001-testable-stage-rtc-and-runner-boundary.md
@@ -25,6 +25,8 @@ The first remote runner path will be SSH-first, with allowlisted operations, bec
 
 The design must keep a clean RTC/event seam so that a persistent runner channel, likely WebSocket over SSH tunnel, can be added later without rewriting plugins or session logic.
 
+For this ADR, “RTC seam” means an internal boundary for commands/events/results. It does **not** mean the testable stage must ship WebRTC, a signalling server, or a continuous media stream.
+
 WebRTC is deferred until a test session proves that continuous media or low-latency streaming is needed.
 
 ## Consequences
@@ -33,7 +35,15 @@ WebRTC is deferred until a test session proves that continuous media or low-late
 - Remote operations stay auditable and narrow.
 - Plugins should not know whether they run locally or remotely; runner plumbing owns that.
 - CLI/API surfaces should accept a host/runner target without leaking raw SSH commands everywhere.
+- Dry-run, fake-runner, and local-runner tests can prove most behaviour before touching `bigchoof`.
 - If the couch feel depends on live continuous presence, a later ADR should choose WebSocket/WebRTC explicitly.
+
+## Boundary invariants
+
+- The coordinator assembles moments and writes the journal; it does not execute raw remote commands.
+- The runner returns artifact/result metadata; it does not decide Discord wording or session policy.
+- The plugin supplies game/context semantics; it does not know whether capture happened locally, over SSH, or through a future event channel.
+- The transport receives an already-assembled moment payload; it does not capture screenshots or mutate runner state.
 
 ## Non-goals
 

--- a/docs/evals/testable-couch-session.md
+++ b/docs/evals/testable-couch-session.md
@@ -13,6 +13,23 @@ This eval is about feel as much as plumbing: does it create the sense of Pip/Cod
 - A Discord couch room/thread exists or can be reused.
 - Remote runner or local fallback can capture a screenshot.
 - Dry-run mode has already passed.
+- The evaluator has a safe place to store the after-action note, such as `state/evals/<date>-couch-session.md`.
+
+## Dry-run rehearsal
+
+Run this before involving the real game/Discord path:
+
+```bash
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff"
+game-couch share --note "dry-run moment" --screenshot ./fixtures/moment.png --transport dry-run
+```
+
+Confirm:
+
+- no Discord message was sent;
+- a session directory exists;
+- the moment is journaled;
+- the payload includes game id, player label, note, trigger, and media path.
 
 ## Script
 
@@ -30,6 +47,22 @@ This eval is about feel as much as plumbing: does it create the sense of Pip/Cod
 6. Review the local journal.
    - Confirm session start and both moments are preserved.
 7. Write a short after-action note.
+
+Use this after-action note shape:
+
+```markdown
+# Game Couch eval — YYYY-MM-DD
+
+- Game / scene:
+- Host / runner:
+- Discord target:
+- Moments triggered:
+- What felt sofa-like:
+- What broke flow:
+- What Pip/Coda could infer from the moment:
+- Next missing feature:
+- Follow-up issues:
+```
 
 ## Pass Signals
 

--- a/docs/testable-stage-plan.md
+++ b/docs/testable-stage-plan.md
@@ -30,6 +30,25 @@ Separate four responsibilities:
 
 The current MVP has coordinator/plugin/transport collapsed into local CLI code. The next stage should pull them apart without overbuilding.
 
+### Boundary contract for the testable stage
+
+The point of the split is not purity. It is so a goblin can change one layer without silently changing another.
+
+| Layer | Owns | Must not own yet | Testable-stage proof |
+| --- | --- | --- | --- |
+| Coordinator | session id, player/game labels, journal path, moment assembly, policy checks, transport selection | raw SSH commands, Discord API details, game-specific interpretation | fake runner + dry-run transport can create a journaled moment |
+| Runner | allowlisted host operations such as `capture_screenshot`, artifact staging/fetch, runner health | session policy, Discord posting, plugin semantics | local/fake/SSH runners expose the same operation result shape |
+| Plugin | context fields for `generic-screen`, future game-specific prompts/labels, capture requirements | remote execution, Discord formatting, persistent session state | `generic-screen` works with local or remote screenshots |
+| Transport / RTC seam | delivery of moment payloads/events to Discord or dry-run sinks | screenshot capture, game interpretation, journal authority | dry-run and Discord transports receive the same assembled moment payload |
+
+Minimum shared data shapes:
+
+- **Runner capture result**: `operation`, `host`, `artifact_path`, `media_type`, `captured_at`, `metadata`, `warnings`.
+- **Moment payload**: `session_id`, `game_id`, `player_label`, `trigger`, `note`, `artifact_path`, `plugin_context`, `created_at`.
+- **Journal event**: `event_type`, `session_id`, `created_at`, `payload`, `transport_result`.
+
+If a change needs a new shared shape, update this plan or an ADR before implementing the feature.
+
 ## RTC Direction
 
 Use “RTC” as a project question, not an immediate commitment to WebRTC everywhere.
@@ -62,6 +81,22 @@ Decision for now: **do SSH-first runner plumbing with a clean RTC/event seam**, 
 - Dry-run and fake-runner tests.
 - A documented manual test script for one real play session.
 - Session scrapbook/journal enough to review afterwards.
+
+### Minimum CLI story
+
+The exact flags may change during implementation, but the first runnable story should stay this small:
+
+```bash
+# one-time/local dry run
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff"
+game-couch share --note "opening scene" --screenshot ./fixtures/moment.png --transport dry-run
+
+# real household test shape
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff" --host bigchoof
+game-couch share --host bigchoof --note "look at this bit" --transport discord
+```
+
+The important behaviour is that `--host bigchoof` selects a configured runner target; it must not become arbitrary shell execution through the CLI.
 
 ### Out of scope
 
@@ -134,6 +169,19 @@ Done when:
 - Should Discord session creation be handled by OpenClaw tooling, a Discord bot token, or webhook plus existing channel conventions?
 - What is the first real game/test scenario? Generic desktop capture is enough technically, but the feel test needs an actual game.
 - Do Pip and Coda both need automatic notification/participation routing in v1, or is Pip-only acceptable for the first test?
+
+## Goblin Stop Lines
+
+Do not add these during the testable-stage issues unless a later issue explicitly asks for them:
+
+- persistent video streaming
+- WebRTC signalling servers
+- autonomous input/control
+- OCR/vision summaries as required plumbing
+- game-specific plugin work beyond `generic-screen`
+- arbitrary shell commands from Discord or CLI
+
+If the first manual eval proves one of these is necessary, file a follow-up issue with the eval evidence.
 
 ## Goblin Wrangler Notes
 


### PR DESCRIPTION
Closes #4\n\n## Summary\n- define coordinator/runner/plugin/transport boundary contract and shared payload shapes\n- clarify RTC seam vs WebRTC deferral and add goblin stop-lines\n- make the manual eval rehearsal and after-action template concrete\n- align README/Roadmap with the testable-stage contract\n\n## Verification\n- pytest -q\n- git diff --check