### PR TITLE
docs: sharpen couch-session commentator eval

### DIFF
--- a/docs/evals/testable-couch-session.md
+++ b/docs/evals/testable-couch-session.md
@@ -6,6 +6,8 @@ Run one real or near-real Game Couch session and decide what features the projec
 
 This eval is about feel as much as plumbing: does it create the sense of Pip/Coda being present on the sofa while Saff plays?
 
+The commentator lens matters: do not only ask whether a command executed. Ask whether the posted moment gives a watcher enough shared object, timing, and invitation to make a natural couch-side comment.
+
 ## Preconditions
 
 - Game is running on the target machine, ideally `bigchoof`.
@@ -18,15 +20,19 @@ This eval is about feel as much as plumbing: does it create the sense of Pip/Cod
 
 1. Start a session.
    - Record game name, host, player label, Discord target.
+   - Record whether Pip/Coda are already present in the Discord surface or need to be pulled in manually.
 2. Trigger a first moment with a note.
    - Example: “opening scene / first impression”.
+   - The note should be short enough that it could plausibly be typed while playing.
 3. Confirm Discord receives the moment.
    - Screenshot/media visible.
    - Note and metadata understandable.
    - No unwanted pings.
 4. Pip reacts in Discord as Pip, not as a hidden merged bot.
+   - Assess whether the reaction refers to the actual posted object rather than generic encouragement.
 5. Trigger a second moment without over-explaining.
    - Check whether the screenshot/context is enough to respond naturally.
+   - If the watcher has to ask “what am I looking at?”, capture that as a context gap rather than papering it over with explanation.
 6. Review the local journal.
    - Confirm session start and both moments are preserved.
 7. Write a short after-action note.
@@ -39,11 +45,26 @@ This eval is about feel as much as plumbing: does it create the sense of Pip/Cod
 - The journal is useful afterwards.
 - The next missing feature is obvious from the session.
 
+## Commentator Rubric
+
+For each posted moment, score the watcher experience before discussing implementation fixes:
+
+| Check | Pass | Fail |
+| --- | --- | --- |
+| Shared object | A specific visible thing can be pointed at. | The screenshot/note is too vague to know what matters. |
+| Timing | The moment arrives close enough to feel live. | The post feels like a delayed scrapbook entry. |
+| Invitation | A natural reaction is obvious: joke, question, surprise, advice, or sympathy. | The only possible response is generic “nice” or admin chatter. |
+| Player flow | Triggering did not noticeably interrupt play. | Capturing the moment became the main activity. |
+| Agent separateness | Pip/Coda can respond as themselves in the room. | The harness voice swallows the participants. |
+
+If plumbing succeeds but the commentator rubric fails, treat the eval as a product failure with useful evidence, not a pass.
+
 ## Failure Signals
 
 - Capture is too fiddly.
 - Discord posts are noisy or ugly.
 - Pip lacks enough context to react.
+- Pip/Coda can only make generic comments because the moment lacks a clear object or invitation.
 - Remote execution feels unsafe or opaque.
 - The journal is too raw to review.
 


### PR DESCRIPTION
## Summary
- Adds a commentator lens to the manual couch-session eval so it checks shared object, timing, and invitation rather than command success alone.
- Adds script prompts for Pip/Coda presence, in-flow notes, object-specific reactions, and context-gap capture.
- Adds a rubric for shared object, timing, invitation, player flow, and agent separateness.
- Adds a failure signal for generic-only comments when the posted moment lacks a clear object/invitation.

## Verification
- Local content assertion for: `Commentator Rubric`, `Shared object`, `natural couch-side comment`, `generic comments`.

Closes #9