### PR TITLE
feat: add remote runner seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ Safest dry-run flow:
 game-couch share --note "look at this jump" --screenshot ~/Desktop/moment.png --transport dry-run
 ```
 
-If `--screenshot` is omitted, `generic-screen` attempts a one-shot macOS `screencapture`. On other systems, pass a screenshot path explicitly.
+If `--screenshot` is omitted, Game Couch asks a runner to capture one screenshot. The default `local` runner uses one-shot macOS `screencapture`; tests can use `--runner fake` without touching the real screen.
+
+## Remote runner seam
+
+A session can remember a named host, and `share` can target a named SSH runner when no screenshot path is provided:
+
+```bash
+export GAME_COUCH_HOST_BIGCHOOF_SSH="saff@bigchoof"
+export GAME_COUCH_HOST_BIGCHOOF_REMOTE_DIR="~/game-couch-captures"  # optional
+
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff" --host bigchoof
+game-couch share --note "look at this jump" --transport dry-run
+```
+
+The SSH runner has an allowlisted first operation only: `capture_screenshot`. It constructs `ssh` + `scp` commands for that operation and does not expose arbitrary remote shell passthrough.
 
 Moment payloads include:
 

--- a/src/game_couch/cli.py
+++ b/src/game_couch/cli.py
@@ -17,6 +17,7 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--game", required=True, choices=available_plugins())
     start.add_argument("--channel", required=True, help="Discord channel/thread target label or id.")
     start.add_argument("--player-label", default="Player")
+    start.add_argument("--host", default=None, help="Named remote host/runner target, e.g. bigchoof.")
     start.add_argument("--new", action="store_true", help="Force a new session instead of reusing the current matching one.")
     start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
@@ -25,6 +26,8 @@ def build_parser() -> argparse.ArgumentParser:
     share.add_argument("--screenshot", type=Path, default=None, help="Existing screenshot/media path. If omitted, generic-screen tries local capture.")
     share.add_argument("--trigger", default="manual")
     share.add_argument("--transport", choices=["dry-run", "discord"], default="dry-run")
+    share.add_argument("--runner", choices=["local", "fake"], default=None, help="Runner to use when --screenshot is omitted.")
+    share.add_argument("--host", default=None, help="Named SSH runner target; overrides session host for this share.")
     share.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
     sub.add_parser("plugins", help="List available game plugins.")
@@ -41,6 +44,7 @@ def main(argv: list[str] | None = None) -> int:
                 channel=args.channel,
                 player_label=args.player_label,
                 force_new=args.new,
+                host=args.host,
             )
             output = {"session": session.to_dict(), "reused": reused, "plugin_context": plugin_context}
             if args.json:
@@ -56,6 +60,8 @@ def main(argv: list[str] | None = None) -> int:
                 screenshot=args.screenshot,
                 trigger=args.trigger,
                 transport_name=args.transport,
+                runner_name=args.runner,
+                host=args.host,
             )
             output = {"session": session.to_dict(), "payload": payload, "transport": result}
             if args.json:

--- a/src/game_couch/models.py
+++ b/src/game_couch/models.py
@@ -22,6 +22,7 @@ class SessionContext:
     game_id: str
     channel: str
     player_label: str = "Player"
+    host: str | None = None
     created_at: str = field(default_factory=utc_now_iso)
     journal_path: str | None = None
 

--- a/src/game_couch/runner.py
+++ b/src/game_couch/runner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+import os
+import shlex
+import shutil
+import subprocess
+from typing import Any, Protocol
+
+from .models import utc_now_iso
+
+
+@dataclass(slots=True)
+class RunnerCaptureResult:
+    operation: str
+    host: str
+    artifact_path: str
+    media_type: str = "image/png"
+    captured_at: str = field(default_factory=utc_now_iso)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class Runner(Protocol):
+    name: str
+
+    def capture_screenshot(self, destination: Path, *, trigger: str = "manual") -> RunnerCaptureResult:
+        ...
+
+
+class LocalRunner:
+    name = "local"
+
+    def capture_screenshot(self, destination: Path, *, trigger: str = "manual") -> RunnerCaptureResult:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if shutil.which("screencapture"):
+            subprocess.run(["screencapture", "-x", str(destination)], check=True)
+            return RunnerCaptureResult(
+                operation="capture_screenshot",
+                host=self.name,
+                artifact_path=str(destination),
+                metadata={"runner": self.name, "trigger": trigger, "command": "screencapture"},
+            )
+        raise RuntimeError("Local screenshot capture requires macOS screencapture; pass --screenshot or use --runner fake.")
+
+
+class FakeRunner:
+    name = "fake"
+
+    def capture_screenshot(self, destination: Path, *, trigger: str = "manual") -> RunnerCaptureResult:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"fake-game-couch-screenshot\n")
+        return RunnerCaptureResult(
+            operation="capture_screenshot",
+            host=self.name,
+            artifact_path=str(destination),
+            metadata={"runner": self.name, "trigger": trigger},
+        )
+
+
+ALLOWED_OPERATIONS = {"capture_screenshot"}
+
+
+@dataclass(slots=True)
+class SshRunnerConfig:
+    name: str
+    target: str
+    remote_dir: str = "~/game-couch-captures"
+    ssh_bin: str = "ssh"
+    scp_bin: str = "scp"
+
+
+def host_env_key(name: str, suffix: str) -> str:
+    safe = "".join(ch if ch.isalnum() else "_" for ch in name.upper())
+    return f"GAME_COUCH_HOST_{safe}_{suffix}"
+
+
+def load_ssh_config(name: str) -> SshRunnerConfig:
+    target = os.environ.get(host_env_key(name, "SSH"))
+    if not target:
+        raise RuntimeError(f"No SSH target configured for host '{name}'. Set {host_env_key(name, 'SSH')}.")
+    return SshRunnerConfig(
+        name=name,
+        target=target,
+        remote_dir=os.environ.get(host_env_key(name, "REMOTE_DIR"), "~/game-couch-captures"),
+    )
+
+
+class SshRunner:
+    def __init__(self, config: SshRunnerConfig):
+        self.config = config
+        self.name = config.name
+
+    def build_remote_capture_command(self, remote_path: str) -> list[str]:
+        quoted_dir = shlex.quote(str(Path(remote_path).parent))
+        quoted_path = shlex.quote(remote_path)
+        # Allowlisted operation only: create dir and capture screenshot on the remote macOS host.
+        return ["mkdir", "-p", quoted_dir, "&&", "screencapture", "-x", quoted_path]
+
+    def build_ssh_command(self, remote_path: str) -> list[str]:
+        remote_script = " ".join(self.build_remote_capture_command(remote_path))
+        return [self.config.ssh_bin, self.config.target, remote_script]
+
+    def build_scp_command(self, remote_path: str, destination: Path) -> list[str]:
+        return [self.config.scp_bin, f"{self.config.target}:{remote_path}", str(destination)]
+
+    def capture_screenshot(self, destination: Path, *, trigger: str = "manual") -> RunnerCaptureResult:
+        operation = "capture_screenshot"
+        if operation not in ALLOWED_OPERATIONS:
+            raise RuntimeError(f"Operation not allowlisted: {operation}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        remote_path = f"{self.config.remote_dir.rstrip('/')}/{destination.name}"
+        subprocess.run(self.build_ssh_command(remote_path), check=True)
+        subprocess.run(self.build_scp_command(remote_path, destination), check=True)
+        return RunnerCaptureResult(
+            operation=operation,
+            host=self.config.name,
+            artifact_path=str(destination),
+            metadata={
+                "runner": "ssh",
+                "target": self.config.target,
+                "remote_path": remote_path,
+                "trigger": trigger,
+            },
+        )
+
+
+def make_runner(name: str | None = None, *, host: str | None = None) -> Runner:
+    if host:
+        return SshRunner(load_ssh_config(host))
+    if not name or name == "local":
+        return LocalRunner()
+    if name == "fake":
+        return FakeRunner()
+    if name.startswith("ssh:"):
+        return SshRunner(load_ssh_config(name.split(":", 1)[1]))
+    raise ValueError(f"Unknown runner: {name}")

--- a/src/game_couch/service.py
+++ b/src/game_couch/service.py
@@ -7,6 +7,7 @@ from .journal import Journal
 from .models import SessionContext, new_session_id, shape_moment_payload
 from .paths import couch_home, current_session_path, sessions_dir
 from .plugins.registry import load_plugin
+from .runner import make_runner
 from .transport import make_transport
 
 
@@ -15,6 +16,7 @@ def start_session(
     game_id: str,
     channel: str,
     player_label: str = "Player",
+    host: str | None = None,
     home: Path | None = None,
     force_new: bool = False,
 ) -> tuple[SessionContext, bool, dict]:
@@ -22,7 +24,7 @@ def start_session(
     current_path = current_session_path(home)
     if not force_new and current_path.exists():
         current = SessionContext.from_dict(json.loads(current_path.read_text(encoding="utf-8")))
-        if current.game_id == game_id and current.channel == channel and current.player_label == player_label:
+        if current.game_id == game_id and current.channel == channel and current.player_label == player_label and current.host == host:
             plugin_context = load_plugin(game_id).start_context(current)
             Journal(current).append_session_started(current, reused=True)
             return current, True, plugin_context
@@ -35,6 +37,7 @@ def start_session(
         game_id=game_id,
         channel=channel,
         player_label=player_label,
+        host=host,
         journal_path=str(session_dir / "journal.jsonl"),
     )
     plugin_context = load_plugin(game_id).start_context(session)
@@ -58,6 +61,8 @@ def share_moment(
     screenshot: Path | None,
     trigger: str = "manual",
     transport_name: str = "dry-run",
+    runner_name: str | None = None,
+    host: str | None = None,
     home: Path | None = None,
 ) -> tuple[SessionContext, dict, dict]:
     home = home or couch_home()
@@ -67,13 +72,17 @@ def share_moment(
     screenshot_path = screenshot
     if screenshot_path is None:
         captures_dir = sessions_dir(home) / session.session_id / "captures"
-        screenshot_path = plugin.capture_screenshot(captures_dir / f"{trigger}.png")
+        runner = make_runner(runner_name, host=host or (session.host if runner_name is None else None))
+        capture_result = runner.capture_screenshot(captures_dir / f"{trigger}.png", trigger=trigger)
+        screenshot_path = Path(capture_result.artifact_path)
     else:
         screenshot_path = screenshot_path.expanduser().resolve()
         if not screenshot_path.exists():
             raise FileNotFoundError(f"Screenshot does not exist: {screenshot_path}")
 
     plugin_context = plugin.capture_moment_context(session=session, screenshot_path=screenshot_path)
+    if screenshot is None:
+        plugin_context["runner"] = capture_result.to_dict()
     payload = shape_moment_payload(
         session=session,
         trigger=trigger,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from game_couch.cli import main
 
@@ -23,3 +24,26 @@ def test_cli_start_and_share_dry_run(tmp_path, monkeypatch, capsys):
     assert share_output["payload"]["note"] == "nice jump"
     assert share_output["transport"]["transport"] == "dry-run"
     assert (tmp_path / "home" / "sessions" / session["session_id"] / "journal.jsonl").exists()
+
+def test_cli_start_with_host_and_share_fake_runner(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("GAME_COUCH_HOME", str(tmp_path / "home"))
+
+    assert main([
+        "start",
+        "--game", "generic-screen",
+        "--channel", "#games",
+        "--player-label", "Saff",
+        "--host", "bigchoof",
+        "--json",
+    ]) == 0
+    start_output = json.loads(capsys.readouterr().out)
+    session = start_output["session"]
+    assert session["host"] == "bigchoof"
+
+    assert main(["share", "--note", "remote-ish", "--runner", "fake", "--transport", "dry-run", "--json"]) == 0
+    share_output = json.loads(capsys.readouterr().out)
+    runner = share_output["payload"]["plugin_context"]["runner"]
+    assert runner["operation"] == "capture_screenshot"
+    assert runner["host"] == "fake"
+    assert Path(runner["artifact_path"]).exists()
+

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from game_couch.runner import FakeRunner, SshRunner, SshRunnerConfig, host_env_key, make_runner
+
+
+def test_fake_runner_writes_artifact(tmp_path):
+    dest = tmp_path / "screen.png"
+    result = FakeRunner().capture_screenshot(dest, trigger="manual")
+    assert dest.exists()
+    assert result.operation == "capture_screenshot"
+    assert result.host == "fake"
+    assert result.metadata["trigger"] == "manual"
+
+
+def test_ssh_runner_builds_allowlisted_commands_without_live_ssh(tmp_path):
+    runner = SshRunner(SshRunnerConfig(name="bigchoof", target="saff@bigchoof", remote_dir="~/gc"))
+    remote = "~/gc/moment.png"
+    assert runner.build_ssh_command(remote) == [
+        "ssh",
+        "saff@bigchoof",
+        "mkdir -p '~/gc' && screencapture -x '~/gc/moment.png'",
+    ]
+    assert runner.build_scp_command(remote, tmp_path / "moment.png") == [
+        "scp",
+        "saff@bigchoof:~/gc/moment.png",
+        str(tmp_path / "moment.png"),
+    ]
+
+
+def test_make_runner_requires_named_host_config(monkeypatch):
+    monkeypatch.delenv(host_env_key("bigchoof", "SSH"), raising=False)
+    with pytest.raises(RuntimeError, match="No SSH target configured"):
+        make_runner(host="bigchoof")
+
+
+def test_make_runner_loads_named_host_from_env(monkeypatch):
+    monkeypatch.setenv(host_env_key("bigchoof", "SSH"), "saff@bigchoof")
+    monkeypatch.setenv(host_env_key("bigchoof", "REMOTE_DIR"), "~/captures")
+    runner = make_runner(host="bigchoof")
+    assert isinstance(runner, SshRunner)
+    assert runner.config.target == "saff@bigchoof"
+    assert runner.config.remote_dir == "~/captures"


### PR DESCRIPTION
Closes #5

## Summary
- adds runner abstraction with local, fake, and named SSH runner implementations
- supports session/one-shot host targeting without arbitrary remote shell passthrough
- records runner capture metadata in moment plugin context and documents bigchoof-style setup

## Tests
- pytest -q