### PR TITLE
feat: attach media to Discord couch moments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,25 @@ Moment payloads include:
 
 ## Discord config
 
-The MVP Discord transport posts via webhook:
+The MVP Discord transport posts via webhook. For the testable stage, create or pick the couch room/thread in Discord first, create a webhook for that target, then start Game Couch with the same target label so the session and journal name where the moment went:
 
 ```bash
 export GAME_COUCH_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+game-couch start --game generic-screen --channel "#game-couch" --player-label "Saff"
 game-couch share --note "boss down" --screenshot ~/Desktop/moment.png --transport discord
 ```
 
+Moment posts include safe mention settings (`allowed_mentions.parse=[]`) and attach the screenshot/media file when the media path exists. If the file is missing, Game Couch still posts the structured text payload and records the missing media in delivery metadata.
+
 Do not commit webhook URLs or bot tokens. Tests and local development should prefer `--transport dry-run`.
+
+### Manual Discord media smoke
+
+1. Start with dry-run and inspect `dry-run-outbox.jsonl` to confirm note, player, game, session, trigger, timestamp, and media metadata.
+2. Set `GAME_COUCH_DISCORD_WEBHOOK_URL` for a private test channel/thread.
+3. Run `game-couch share --note "media smoke" --screenshot <png> --transport discord`.
+4. Confirm Discord shows one message with the screenshot attachment and no accidental pings.
+5. Inspect the session journal for the `moment.shared` event and Discord transport status.
 
 ## Plugin interface
 

--- a/src/game_couch/transport.py
+++ b/src/game_couch/transport.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 import json
+import mimetypes
 import os
 import urllib.request
 
@@ -21,12 +23,24 @@ class DryRunTransport(Transport):
         self.outbox_path = outbox_path
 
     def send_moment(self, *, session: SessionContext, payload: MomentPayload) -> dict[str, Any]:
-        record = {"channel": session.channel, "payload": payload.to_dict()}
+        media_path = Path(payload.media_path).expanduser() if payload.media_path else None
+        record = {
+            "channel": session.channel,
+            "payload": payload.to_dict(),
+            "media": media_record(media_path),
+            "message": format_discord_message(session=session, payload=payload),
+        }
         if self.outbox_path:
             self.outbox_path.parent.mkdir(parents=True, exist_ok=True)
             with self.outbox_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(record, sort_keys=True) + "\n")
-        return {"transport": "dry-run", "delivered": False, "channel": session.channel, "outbox": str(self.outbox_path) if self.outbox_path else None}
+        return {
+            "transport": "dry-run",
+            "delivered": False,
+            "channel": session.channel,
+            "outbox": str(self.outbox_path) if self.outbox_path else None,
+            "media": record["media"],
+        }
 
 
 class DiscordWebhookTransport(Transport):
@@ -40,15 +54,53 @@ class DiscordWebhookTransport(Transport):
             "content": format_discord_message(session=session, payload=payload),
             "allowed_mentions": {"parse": []},
         }
+        media_path = Path(payload.media_path).expanduser() if payload.media_path else None
+        media = media_record(media_path)
+        if media_path and media_path.exists():
+            data, content_type = encode_multipart_payload(body=body, media_path=media_path)
+        else:
+            data = json.dumps(body).encode("utf-8")
+            content_type = "application/json"
         request = urllib.request.Request(
             self.webhook_url,
-            data=json.dumps(body).encode("utf-8"),
-            headers={"Content-Type": "application/json", "User-Agent": "game-couch/0.1"},
+            data=data,
+            headers={"Content-Type": content_type, "User-Agent": "game-couch/0.1"},
             method="POST",
         )
         with urllib.request.urlopen(request, timeout=15) as response:  # noqa: S310 - user-configured Discord webhook
             status = response.getcode()
-        return {"transport": "discord-webhook", "delivered": True, "channel": session.channel, "status": status}
+        return {"transport": "discord-webhook", "delivered": True, "channel": session.channel, "status": status, "media": media}
+
+
+def media_record(media_path: Path | None) -> dict[str, Any] | None:
+    if not media_path:
+        return None
+    return {
+        "path": str(media_path),
+        "filename": media_path.name,
+        "exists": media_path.exists(),
+        "content_type": mimetypes.guess_type(media_path.name)[0] or "application/octet-stream",
+    }
+
+
+def encode_multipart_payload(*, body: dict[str, Any], media_path: Path) -> tuple[bytes, str]:
+    boundary = f"game-couch-{uuid4().hex}"
+    content_type = mimetypes.guess_type(media_path.name)[0] or "application/octet-stream"
+    parts: list[bytes] = []
+
+    def add_field(name: str, value: bytes, *, filename: str | None = None, field_content_type: str | None = None) -> None:
+        disposition = f'form-data; name="{name}"'
+        if filename:
+            disposition += f'; filename="{filename}"'
+        headers = [f"--{boundary}", f"Content-Disposition: {disposition}"]
+        if field_content_type:
+            headers.append(f"Content-Type: {field_content_type}")
+        parts.append(("\r\n".join(headers) + "\r\n\r\n").encode("utf-8") + value + b"\r\n")
+
+    add_field("payload_json", json.dumps(body).encode("utf-8"), field_content_type="application/json")
+    add_field("files[0]", media_path.read_bytes(), filename=media_path.name, field_content_type=content_type)
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
 
 
 def format_discord_message(*, session: SessionContext, payload: MomentPayload) -> str:

--- a/tests/test_journal_transport.py
+++ b/tests/test_journal_transport.py
@@ -33,3 +33,73 @@ def test_journal_writes_jsonl_and_dry_run_transport_records_outbox(tmp_path):
     assert outbox_record["payload"]["session_id"] == "s1"
     assert journal_record["kind"] == "moment.shared"
     assert journal_record["data"]["payload"]["game_id"] == "generic-screen"
+
+from game_couch.transport import encode_multipart_payload, format_discord_message
+
+
+def test_dry_run_transport_records_media_and_safe_message(tmp_path):
+    screenshot = tmp_path / "moment.png"
+    screenshot.write_bytes(b"fake-png")
+    session = SessionContext(
+        session_id="s2",
+        game_id="generic-screen",
+        channel="#games",
+        player_label="Saff",
+        journal_path=str(tmp_path / "journal.jsonl"),
+    )
+    payload = shape_moment_payload(
+        session=session,
+        trigger="manual",
+        note="look @everyone no ping",
+        screenshot_path=screenshot,
+        plugin_context={"plugin": "generic-screen"},
+        timestamp="2026-04-28T21:00:00Z",
+    )
+    outbox = tmp_path / "outbox.jsonl"
+
+    result = DryRunTransport(outbox).send_moment(session=session, payload=payload)
+    outbox_record = json.loads(outbox.read_text().splitlines()[0])
+
+    assert result["media"] == {
+        "path": str(screenshot),
+        "filename": "moment.png",
+        "exists": True,
+        "content_type": "image/png",
+    }
+    assert outbox_record["media"]["filename"] == "moment.png"
+    assert "Player: **Saff**" in outbox_record["message"]
+    assert "Trigger: `manual`" in outbox_record["message"]
+    assert "look @everyone no ping" in outbox_record["message"]
+
+
+def test_format_discord_message_contains_required_metadata(tmp_path):
+    session = SessionContext(session_id="s3", game_id="generic-screen", channel="#games", player_label="Saff")
+    payload = shape_moment_payload(
+        session=session,
+        trigger="hotkey",
+        note="boss down",
+        screenshot_path=tmp_path / "boss.png",
+        plugin_context={"plugin": "generic-screen"},
+        timestamp="2026-04-28T21:00:00Z",
+    )
+    text = format_discord_message(session=session, payload=payload)
+    assert "generic-screen" in text
+    assert "s3" in text
+    assert "Saff" in text
+    assert "hotkey" in text
+    assert "2026-04-28T21:00:00Z" in text
+    assert "boss down" in text
+
+
+def test_multipart_payload_includes_json_and_media(tmp_path):
+    screenshot = tmp_path / "moment.png"
+    screenshot.write_bytes(b"fake-png")
+    body = {"content": "hello", "allowed_mentions": {"parse": []}}
+
+    data, content_type = encode_multipart_payload(body=body, media_path=screenshot)
+
+    assert content_type.startswith("multipart/form-data; boundary=game-couch-")
+    assert b'name="payload_json"' in data
+    assert b'"allowed_mentions": {"parse": []}' in data
+    assert b'name="files[0]"; filename="moment.png"' in data
+    assert b"fake-png" in data


### PR DESCRIPTION
Closes #6

## Summary
- posts existing screenshot/media paths as Discord webhook multipart attachments
- records media metadata and formatted message content in dry-run outbox for testable inspection
- documents couch-room target selection and manual Discord media smoke path

## Tests
- pytest -q
- PYTHONPATH=src game-couch dry-run media smoke
